### PR TITLE
Clockify Add serveUrl to manifest to enable [sc-189160]

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,
+  "serveUrl": "https://apps-cdn.deskpro-service.com/__name__/__version__",
   "targets": [{ "target": "ticket_sidebar", "entrypoint": "index.html" }],
   "proxy": {
     "whitelist": [


### PR DESCRIPTION
Allow serving the app from the CDN instead of always been local. For example: https://apps-cdn.deskpro-service.com/@deskpro-apps/clockify/1.0.21/index.html